### PR TITLE
Pytest configuration via pytest.ini

### DIFF
--- a/django/pytest.ini
+++ b/django/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = core.settings.test
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
Configures pytest via pytest.ini. The `DJANGO_SETTINGS_MODULE` variable indicates that `/core/settings/test.py` settings module should be used for tests. `python_files`  instructs pytest to collect tests in Django’s default app layouts.