### PR TITLE
Updates for simpler Caddyfiles

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -13,7 +13,7 @@ COMPOSE_FILE=docker-compose.local.yml
 # your app's domain .e.g. `example.com` (localhost for development)
 DOMAIN=localhost
 
-# you app's port (81 by default for development)
+# you app's port (81 for development)
 PORT=81
 
 # the Caddyfile used to configure the caddy server

--- a/docker/caddy/Caddyfile.dev
+++ b/docker/caddy/Caddyfile.dev
@@ -3,7 +3,7 @@ import Caddyfile.base
 # SITES
 # https://caddyserver.com/docs/caddyfile-tutorial#multiple-sites
 
-{$DOMAIN}:{$PORT} {
+{$DOMAIN} {
     basicauth {
         # basicauth to keep the bots out
         # user:pass | 'caddy:caddy'

--- a/docker/caddy/Caddyfile.prod
+++ b/docker/caddy/Caddyfile.prod
@@ -3,7 +3,7 @@ import Caddyfile.base
 # SITES
 # https://caddyserver.com/docs/caddyfile-tutorial#multiple-sites
 
-{$DOMAIN}:{$PORT} {
+{$DOMAIN} {
     import site_base
 
     # reverse proxy all requests


### PR DESCRIPTION
`Caddyfile.dev` and `Caddyfile.prod` don't need to read the port from the `.env` file. They'll just use the default 80 and 443 for http and https respectively.